### PR TITLE
兼容其他平台

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,286 @@
+complex.pdf
+
+## Core latex/pdflatex auxiliary files:
+*.aux
+*.lof
+*.log
+*.lot
+*.fls
+*.out
+*.toc
+*.fmt
+*.fot
+*.cb
+*.cb2
+.*.lb
+
+## Intermediate documents:
+*.dvi
+*.xdv
+*-converted-to.*
+# these rules might exclude image files for figures etc.
+# *.ps
+# *.eps
+# *.pdf
+
+## Generated if empty string is given at "Please type another file name for output:"
+.pdf
+
+## Bibliography auxiliary files (bibtex/biblatex/biber):
+*.bbl
+*.bcf
+*.blg
+*-blx.aux
+*-blx.bib
+*.run.xml
+
+## Build tool auxiliary files:
+*.fdb_latexmk
+*.synctex
+*.synctex(busy)
+*.synctex.gz
+*.synctex.gz(busy)
+*.pdfsync
+
+## Build tool directories for auxiliary files
+# latexrun
+latex.out/
+
+## Auxiliary and intermediate files from other packages:
+# algorithms
+*.alg
+*.loa
+
+# achemso
+acs-*.bib
+
+# amsthm
+*.thm
+
+# beamer
+*.nav
+*.pre
+*.snm
+*.vrb
+
+# changes
+*.soc
+
+# comment
+*.cut
+
+# cprotect
+*.cpt
+
+# elsarticle (documentclass of Elsevier journals)
+*.spl
+
+# endnotes
+*.ent
+
+# fixme
+*.lox
+
+# feynmf/feynmp
+*.mf
+*.mp
+*.t[1-9]
+*.t[1-9][0-9]
+*.tfm
+
+#(r)(e)ledmac/(r)(e)ledpar
+*.end
+*.?end
+*.[1-9]
+*.[1-9][0-9]
+*.[1-9][0-9][0-9]
+*.[1-9]R
+*.[1-9][0-9]R
+*.[1-9][0-9][0-9]R
+*.eledsec[1-9]
+*.eledsec[1-9]R
+*.eledsec[1-9][0-9]
+*.eledsec[1-9][0-9]R
+*.eledsec[1-9][0-9][0-9]
+*.eledsec[1-9][0-9][0-9]R
+
+# glossaries
+*.acn
+*.acr
+*.glg
+*.glo
+*.gls
+*.glsdefs
+*.lzo
+*.lzs
+
+# uncomment this for glossaries-extra (will ignore makeindex's style files!)
+# *.ist
+
+# gnuplottex
+*-gnuplottex-*
+
+# gregoriotex
+*.gaux
+*.gtex
+
+# htlatex
+*.4ct
+*.4tc
+*.idv
+*.lg
+*.trc
+*.xref
+
+# hyperref
+*.brf
+
+# knitr
+*-concordance.tex
+# TODO Uncomment the next line if you use knitr and want to ignore its generated tikz files
+# *.tikz
+*-tikzDictionary
+
+# listings
+*.lol
+
+# luatexja-ruby
+*.ltjruby
+
+# makeidx
+*.idx
+*.ilg
+*.ind
+
+# minitoc
+*.maf
+*.mlf
+*.mlt
+*.mtc[0-9]*
+*.slf[0-9]*
+*.slt[0-9]*
+*.stc[0-9]*
+
+# minted
+_minted*
+*.pyg
+
+# morewrites
+*.mw
+
+# nomencl
+*.nlg
+*.nlo
+*.nls
+
+# pax
+*.pax
+
+# pdfpcnotes
+*.pdfpc
+
+# sagetex
+*.sagetex.sage
+*.sagetex.py
+*.sagetex.scmd
+
+# scrwfile
+*.wrt
+
+# sympy
+*.sout
+*.sympy
+sympy-plots-for-*.tex/
+
+# pdfcomment
+*.upa
+*.upb
+
+# pythontex
+*.pytxcode
+pythontex-files-*/
+
+# tcolorbox
+*.listing
+
+# thmtools
+*.loe
+
+# TikZ & PGF
+*.dpth
+*.md5
+*.auxlock
+
+# todonotes
+*.tdo
+
+# vhistory
+*.hst
+*.ver
+
+# easy-todo
+*.lod
+
+# xcolor
+*.xcp
+
+# xmpincl
+*.xmpi
+
+# xindy
+*.xdy
+
+# xypic precompiled matrices and outlines
+*.xyc
+*.xyd
+
+# endfloat
+*.ttt
+*.fff
+
+# Latexian
+TSWLatexianTemp*
+
+## Editors:
+# WinEdt
+*.bak
+*.sav
+
+# Texpad
+.texpadtmp
+
+# LyX
+*.lyx~
+
+# Kile
+*.backup
+
+# gummi
+.*.swp
+
+# KBibTeX
+*~[0-9]*
+
+# TeXnicCenter
+*.tps
+
+# auto folder when using emacs and auctex
+./auto/*
+*.el
+
+# expex forward references with \gathertags
+*-tags.tex
+
+# standalone packages
+*.sta
+
+# Makeindex log files
+*.lpz
+
+# xwatermark package
+*.xwm
+
+# REVTeX puts footnotes in the bibliography by default, unless the nofootinbib
+# option is specified. Footnotes are the stored in a file with suffix Notes.bib.
+# Uncomment the next line to have this generated file ignored.
+#*Notes.bib

--- a/cover.tex
+++ b/cover.tex
@@ -8,9 +8,6 @@
 \definecolor{right1}{RGB}{240,240,215}
 \definecolor{bottom}{RGB}{8,77,182}
 
-\newcommand{\wryh}[1]{{\CJKfontspec{微软雅黑}#1}}
-\newcommand{\hyds}[1]{{\CJKfontspec{汉仪大宋简}#1}}
-
 \definecolor{colorA}{RGB}{214,199,61}
 \definecolor{colorB}{RGB}{16,166,194}
 \definecolor{colorC}{RGB}{11,127,110}
@@ -54,4 +51,3 @@
 \textcolor{colorC}函 \textcolor{colorD}数}};
 
 \end{tikzpicture}
-

--- a/settings.tex
+++ b/settings.tex
@@ -1,5 +1,9 @@
 \usepackage{etex,tabularx}
 \newcolumntype{Y}{>{\centering\arraybackslash}X}
+\usepackage{fontspec}
+\IfFontExistsTF{FZShuSong-Z01}{
+  \PassOptionsToPackage{ctex}{fontset=founder}
+}{}
 \usepackage[heading]{ctex}
 \usepackage{manfnt}
 \usepackage{indentfirst}
@@ -9,7 +13,9 @@
 \usepackage[centering,
            top=2.54cm,bottom=2.54cm,right=2.9cm,left=2.9cm,
            headsep=25pt,headheight=20pt]{geometry}
-\usepackage[lite,zswash]{mtpro2}
+\IfFileExists{mtpro2.sty}{
+  \usepackage[lite,zswash]{mtpro2}
+}{}
 \usepackage{amssymb}
 \usepackage{amsmath,mathrsfs}
 \usepackage{caption}
@@ -49,7 +55,19 @@ othercode={
 \DeclareSymbolFont{ugmL}{OMX}{yhex}{m}{n}
 \DeclareMathAccent{\wideparen}{\mathord}{ugmL}{"F3}
 
-\setCJKmainfont[BoldFont={方正黑体_GBK},ItalicFont={方正楷体_GBK}]{方正书宋_GBK}
+\IfFontExistsTF{FZShuSong-Z01}{
+  \setCJKmainfont[BoldFont={FZHei-B01},ItalicFont={FZKai-Z03}]{FZShuSong-Z01}
+}{}
+\IfFontExistsTF{Microsoft YaHei}{
+  \newCJKfontfamily\wryh{Microsoft YaHei}
+}{
+  \let\wryh\sffamily
+}
+\IfFontExistsTF{汉仪大宋简}{
+  \newCJKfontfamily\hyds{汉仪大宋简}
+}{
+  \let\hyds\rmfamily
+}
 
 \defaultfontfeatures{Mapping=tex-text}
 \XeTeXlinebreaklocale ”zh”
@@ -81,7 +99,8 @@ after-item-skip=0pt
 
 
 
-\usepackage{fancyhdr,tikz}
+\usepackage{fancyhdr}
+\usepackage{tkz-euclide}
 \usetikzlibrary{shapes.callouts,arrows.meta,calc,shadings}
 \renewcommand{\Re}{\operatorname{\textrm{Re}}}
 \renewcommand{\Im}{\operatorname{\textrm{Im}}}
@@ -94,13 +113,13 @@ after-item-skip=0pt
 
 
 \usepackage{tocloft}
-\renewcommand\cftchapfont{\CJKfontspec{汉仪大宋简}}
+\renewcommand\cftchapfont{\hyds}
 \renewcommand{\cftchapleader}{\cftdotfill{\cftdotsep}}
 \ctexset {
   chapter = {
   beforeskip = 0pt,
   fixskip = true,
-  format = \Huge\CJKfontspec{汉仪大宋简},
+  format = \Huge\hyds,
   nameformat = \rule{\linewidth}{1bp}\par\bigskip\hfill\label{chap\thechapter}\chapternamebox,
   number = \arabic{chapter},
   aftername = \par\medskip,
@@ -109,7 +128,7 @@ after-item-skip=0pt
   section = {
     titleformat+  = \label{sec\thesection}\raggedright
   },
-  contentsname = \CJKfontspec{汉仪大宋简}{目 录}
+  contentsname = \hyds{目 录}
 }
 \newcommand\chapternamebox[1]{%
 \parbox{\ccwd}{\linespread{1}\selectfont\centering #1}}
@@ -227,5 +246,3 @@ after-item-skip=0pt
 \DeclareMathOperator{\SL}{SL}
 \DeclareMathOperator*{\Res}{Res}
 \newcommand\DD{D}
-
-


### PR DESCRIPTION
1. 判断系统中有无 `mtpro2` 宏包并自动调用。
2. 判断系统中有无方正书宋、微软雅黑等字体，并自动调用。

这样可以兼容其他平台，目前可以在 macOS、Overleaf 上编译通过，同时不影响在你自己平台上编译的结果。