### PR TITLE
amssymb is necessary for \mathbb

### DIFF
--- a/settings.tex
+++ b/settings.tex
@@ -19,6 +19,7 @@
   \usepackage[zswash,mtpbb]{mtpro2}
 }{}
 
+\usepackage{amssymb}
 \usepackage{amsmath,mathrsfs}
 \usepackage{caption}
 


### PR DESCRIPTION
Error without `\usepackage{amssymb}`:

```
! Undefined control sequence.
\MR ->\mathbb 
```